### PR TITLE
plugins/flashrom/flashrom.quirk: add new NV4x GUIDs for FW v1.0.1

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -48,7 +48,11 @@ Flags = reset-cmos
 # NovaCustom NV4x (HwId)
 [59caeff5-6a3c-595b-aab1-56500d0fecbc]
 Plugin = flashrom
+[25b6ea34-8f52-598e-a27a-31e03014dbe3]
+Plugin = flashrom
 
 # NovaCustom NV4x (Dasharo GUID)
 [41a8fb3d-213a-5a8a-b0f4-e2a7c55aaf80]
+Branch = dasharo
+[9a8c30e2-1b7e-5b28-9632-fc2fbf8cd0ba]
 Branch = dasharo


### PR DESCRIPTION
Add GUIDs for NovaCustom NV4x running firmware v1.0.1.

Dasharo v1.0.1 changes the GUIDs to the ones which are now supported by upstream fwupd. Currently, the Dasharo fwupd fork supports the older GUIDs. Add the new GUIDs so all versions are recognized properly.